### PR TITLE
Fix web UI updater for non-default install path (fixes #6)

### DIFF
--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,24 @@
+"""Tests for the web UI self-updater."""
+
+import os
+from unittest.mock import Mock
+
+from web_ui.backend.updater import Updater
+
+
+def test_trigger_update_passes_actual_install_dir(monkeypatch, tmp_path):
+    """The update script must receive the path used to construct the updater."""
+    update_script = tmp_path / "update.sh"
+    update_script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    popen = Mock()
+    monkeypatch.setattr("web_ui.backend.updater.subprocess.Popen", popen)
+
+    success, _ = Updater(base_path=str(tmp_path)).trigger_update()
+
+    assert success is True
+    popen.assert_called_once()
+    args, kwargs = popen.call_args
+    assert args[0] == ["/bin/bash", str(update_script)]
+    assert kwargs["cwd"] == str(tmp_path)
+    assert kwargs["env"]["INSTALL_DIR"] == str(tmp_path)
+    assert kwargs["env"]["LOG_FILE"] == os.devnull

--- a/tests/test_web_ui_update_endpoints.py
+++ b/tests/test_web_ui_update_endpoints.py
@@ -1,0 +1,89 @@
+import pytest
+from unittest.mock import Mock
+
+from web_ui.backend import app as app_module
+
+
+@pytest.fixture
+def client():
+    if not getattr(app_module, "FLASK_AVAILABLE", False):
+        pytest.skip("Flask not available")
+    app_module.app.testing = True
+    if getattr(app_module, "cfg", None) is not None:
+        app_module.cfg.setdefault("auth", {})
+        app_module.cfg["auth"]["enabled"] = False
+    return app_module.app.test_client()
+
+
+def test_get_version_returns_payload(client, monkeypatch):
+    updater = Mock()
+    updater.get_current_version.return_value = {"commit_hash": "abc123"}
+    monkeypatch.setattr(app_module, "updater", updater)
+
+    resp = client.get("/api/version")
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"commit_hash": "abc123"}
+    updater.get_current_version.assert_called_once_with()
+
+
+def test_check_version_returns_payload(client, monkeypatch):
+    updater = Mock()
+    updater.check_for_updates.return_value = {"update_available": False}
+    monkeypatch.setattr(app_module, "updater", updater)
+
+    resp = client.get("/api/version/check")
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"update_available": False}
+    updater.check_for_updates.assert_called_once_with()
+
+
+def test_trigger_update_windows_simulation(client, monkeypatch):
+    monkeypatch.setattr(app_module.sys, "platform", "win32")
+
+    resp = client.post("/api/version/update")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "simulated"
+
+
+def test_trigger_update_success(client, monkeypatch):
+    monkeypatch.setattr(app_module.sys, "platform", "linux")
+    updater = Mock()
+    updater.trigger_update.return_value = (True, "Update started")
+    monkeypatch.setattr(app_module, "updater", updater)
+
+    resp = client.post("/api/version/update")
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {
+        "status": "updating",
+        "message": "Update started",
+    }
+    updater.trigger_update.assert_called_once_with()
+
+
+def test_trigger_update_failure(client, monkeypatch):
+    monkeypatch.setattr(app_module.sys, "platform", "linux")
+    updater = Mock()
+    updater.trigger_update.return_value = (False, "Update failed")
+    monkeypatch.setattr(app_module, "updater", updater)
+
+    resp = client.post("/api/version/update")
+
+    assert resp.status_code == 500
+    assert resp.get_json() == {"error": "Update failed"}
+    updater.trigger_update.assert_called_once_with()
+
+
+def test_update_log_returns_payload(client, monkeypatch):
+    updater = Mock()
+    updater.get_update_log.return_value = "log content"
+    monkeypatch.setattr(app_module, "updater", updater)
+
+    resp = client.get("/api/version/log")
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"log": "log content"}
+    updater.get_update_log.assert_called_once_with()

--- a/web_ui/backend/updater.py
+++ b/web_ui/backend/updater.py
@@ -201,9 +201,11 @@ class Updater:
             # Prepare log file
             log_file = os.path.join(self.base_path, "update.log")
 
-            # Prepare environment with LOG_FILE override to avoid writing to system logs
+            # Prepare environment with overrides to avoid writing to system logs
+            # and to ensure the update runs from the actual install path.
             env = os.environ.copy()
             env["LOG_FILE"] = os.devnull
+            env["INSTALL_DIR"] = self.base_path
 
             # Write header to log
             try:


### PR DESCRIPTION
Closes #6

- Pass INSTALL_DIR to update.sh based on actual install path
- Avoid hardcoded /opt/knx_to_openhab assumption