### PR TITLE
feat: harden KNX project uploads

### DIFF
--- a/tests/test_upload_security.py
+++ b/tests/test_upload_security.py
@@ -1,0 +1,112 @@
+import io
+import json
+import os
+import zipfile
+from unittest.mock import Mock
+
+import pytest
+from werkzeug.datastructures import FileStorage
+
+from web_ui.backend.jobs import JobManager
+from web_ui.backend.upload_security import (
+    UploadValidationError,
+    remove_upload,
+    store_validated_upload,
+    validate_project,
+)
+
+
+def _archive(path, members):
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, value in members:
+            archive.writestr(name, value)
+
+
+def test_rejects_path_traversal_archive(tmp_path):
+    project = tmp_path / "bad.knxproj"
+    _archive(project, [("../../outside.txt", "owned")])
+
+    with pytest.raises(UploadValidationError, match="unsafe path"):
+        validate_project(project, project.name)
+
+    assert not (tmp_path.parent / "outside.txt").exists()
+
+
+def test_rejects_too_many_archive_members(tmp_path):
+    project = tmp_path / "many.knxprojarchive"
+    _archive(project, [(f"file-{number}", "x") for number in range(3)])
+
+    with pytest.raises(UploadValidationError, match="too many files"):
+        validate_project(project, project.name, {"max_files": 2})
+
+
+def test_rejects_zip_bomb_by_expanded_size(tmp_path):
+    project = tmp_path / "large.knxproj"
+    _archive(project, [("large.xml", "x" * 10_000)])
+
+    with pytest.raises(UploadValidationError, match="expands beyond"):
+        validate_project(
+            project,
+            project.name,
+            {"max_uncompressed_bytes": 100, "max_compression_ratio": 1000},
+        )
+
+
+def test_extension_and_content_must_both_match(tmp_path):
+    fake_archive = tmp_path / "fake.knxproj"
+    fake_archive.write_text(json.dumps({"project": True}), encoding="utf-8")
+
+    with pytest.raises(UploadValidationError, match="not a valid ZIP"):
+        validate_project(fake_archive, fake_archive.name)
+
+
+def test_invalid_json_is_rejected(tmp_path):
+    project = tmp_path / "project.json"
+    project.write_text("not-json", encoding="utf-8")
+
+    with pytest.raises(UploadValidationError, match="not valid JSON"):
+        validate_project(project, project.name)
+
+
+def test_failed_upload_removes_isolated_directory(tmp_path):
+    upload = FileStorage(stream=io.BytesIO(b"not a zip"), filename="bad.knxproj")
+
+    with pytest.raises(UploadValidationError):
+        store_validated_upload(upload, upload.filename, tmp_path)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_successful_upload_can_be_removed_as_a_unit(tmp_path):
+    data = io.BytesIO()
+    with zipfile.ZipFile(data, "w") as archive:
+        archive.writestr("project.xml", "safe")
+    data.seek(0)
+    upload = FileStorage(stream=data, filename="safe.knxproj")
+
+    path = store_validated_upload(upload, upload.filename, tmp_path)
+    work_dir = os.path.dirname(path)
+    assert os.path.isfile(path)
+
+    remove_upload(path)
+    assert not os.path.exists(work_dir)
+
+
+def test_job_password_is_never_persisted(tmp_path):
+    manager = JobManager(
+        {
+            "jobs_dir": str(tmp_path / "jobs"),
+            "backups_dir": str(tmp_path / "backups"),
+        }
+    )
+    manager.executor.shutdown()
+    manager.executor = Mock()
+    project = tmp_path / "project.json"
+    project.write_text("{}", encoding="utf-8")
+
+    job = manager.create_job(str(project), password="top-secret")
+
+    persisted = (tmp_path / "jobs" / "jobs.json").read_text(encoding="utf-8")
+    assert "top-secret" not in persisted
+    assert "password" not in job
+    assert manager._passwords[job["id"]] == "top-secret"

--- a/web_ui/backend/app.py
+++ b/web_ui/backend/app.py
@@ -270,7 +270,10 @@ if FLASK_AVAILABLE:
             return jsonify({"error": "original input file not found"}), 404
 
         try:
-            new_job = job_mgr.create_job(input_path, original_name=job.get("name"))
+            password = job_mgr.get_job_password(job_id)
+            new_job = job_mgr.create_job(
+                input_path, original_name=job.get("name"), password=password
+            )
             return jsonify(new_job), 201
         except Exception as e:
             return jsonify({"error": str(e)}), 500

--- a/web_ui/backend/app.py
+++ b/web_ui/backend/app.py
@@ -2,7 +2,6 @@ import json
 import os
 import sys
 import tarfile
-import uuid
 from typing import Any, Callable, TypedDict
 
 try:
@@ -36,6 +35,12 @@ from .jobs import JobManager
 from .service_manager import get_service_status, restart_service
 from .storage import load_config
 from .updater import Updater
+from .upload_security import (
+    DEFAULT_MAX_UPLOAD_BYTES,
+    UploadValidationError,
+    remove_upload,
+    store_validated_upload,
+)
 
 cfg = load_config()
 
@@ -68,6 +73,14 @@ if FLASK_AVAILABLE:
         static_url_path="/static",
     )
     app.config["UPLOAD_FOLDER"] = cfg.get("jobs_dir", "./var/lib/knx_to_openhab")
+    app.config["MAX_CONTENT_LENGTH"] = int(
+        cfg.get("upload_security", {}).get("max_upload_bytes", DEFAULT_MAX_UPLOAD_BYTES)
+    )
+
+    @app.errorhandler(413)
+    def upload_too_large(_error):
+        limit_mb = app.config["MAX_CONTENT_LENGTH"] // (1024 * 1024)
+        return jsonify({"error": f"Upload exceeds the {limit_mb} MB size limit."}), 413
 
     # Fix openhab_path to be absolute if it's relative and based on project root
 
@@ -193,12 +206,21 @@ if FLASK_AVAILABLE:
         if f.filename == "":
             return jsonify({"error": "no selected file"}), 400
         fn = secure_filename(f.filename)
-        os.makedirs(app.config["UPLOAD_FOLDER"], exist_ok=True)
-        saved_path = os.path.join(app.config["UPLOAD_FOLDER"], f"{uuid.uuid4().hex}-{fn}")
-        f.save(saved_path)
-        password = request.form.get("password") or None
-        job = job_mgr.create_job(saved_path, original_name=fn, password=password)
-        return jsonify(job), 201
+        saved_path = None
+        try:
+            saved_path = store_validated_upload(
+                f, fn, app.config["UPLOAD_FOLDER"], cfg.get("upload_security", {})
+            )
+            password = request.form.get("password") or None
+            job = job_mgr.create_job(
+                saved_path, original_name=fn, password=password, cleanup_input=True
+            )
+            return jsonify(job), 201
+        except UploadValidationError as error:
+            return jsonify({"error": str(error)}), 400
+        except Exception:
+            remove_upload(saved_path)
+            return jsonify({"error": "Unable to create processing job."}), 500
 
     @app.route("/api/jobs", methods=["GET"])
     def jobs():
@@ -248,10 +270,7 @@ if FLASK_AVAILABLE:
             return jsonify({"error": "original input file not found"}), 404
 
         try:
-            # Create a new job with the same input and password
-            new_job = job_mgr.create_job(
-                input_path, original_name=job.get("name"), password=job.get("password")
-            )
+            new_job = job_mgr.create_job(input_path, original_name=job.get("name"))
             return jsonify(new_job), 201
         except Exception as e:
             return jsonify({"error": str(e)}), 500
@@ -737,12 +756,11 @@ if FLASK_AVAILABLE:
         if f.filename == "":
             return jsonify({"error": "no selected file"}), 400
 
-        # Save to temporary location
         fn = secure_filename(f.filename)
-        temp_path = os.path.join(app.config["UPLOAD_FOLDER"], f"temp_{uuid.uuid4().hex}_{fn}")
-        f.save(temp_path)
-
         try:
+            temp_path = store_validated_upload(
+                f, fn, app.config["UPLOAD_FOLDER"], cfg.get("upload_security", {})
+            )
             password = request.form.get("password") or None
 
             # Load project (json dump or parse knxproj)
@@ -859,17 +877,15 @@ if FLASK_AVAILABLE:
 
             return jsonify(preview_data)
 
+        except UploadValidationError as e:
+            return jsonify({"error": str(e)}), 400
         except Exception as e:
             friendly_msg = _password_error_message(e)
             if friendly_msg:
                 return jsonify({"error": friendly_msg}), 400
             return jsonify({"error": str(e)}), 500
         finally:
-            # Clean up temp file
-            try:
-                os.remove(temp_path)
-            except:
-                pass
+            remove_upload(locals().get("temp_path"))
 
     @app.route("/api/job/<job_id>/deploy", methods=["POST"])
     def job_deploy(job_id):

--- a/web_ui/backend/config.json
+++ b/web_ui/backend/config.json
@@ -4,6 +4,12 @@
   "backups_dir": "var/backups/knx_to_openhab",
   "bind_host": "0.0.0.0",
   "port": 8085,
+  "upload_security": {
+    "max_upload_bytes": 52428800,
+    "max_files": 10000,
+    "max_uncompressed_bytes": 262144000,
+    "max_compression_ratio": 100
+  },
   "auth": {
     "enabled": true,
     "user": "admin",

--- a/web_ui/backend/jobs.py
+++ b/web_ui/backend/jobs.py
@@ -119,6 +119,10 @@ class JobManager:
             return None
         return self.queues.get(job_id)
 
+    def get_job_password(self, job_id):
+        """Return the in-memory password for a job, if any."""
+        return self._passwords.get(job_id)
+
     def create_job(self, input_path, original_name=None, password=None, cleanup_input=False):
         job_id = uuid.uuid4().hex
         job = {

--- a/web_ui/backend/jobs.py
+++ b/web_ui/backend/jobs.py
@@ -16,6 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 from completeness import check_completeness, iter_thing_lines
 
 from .storage import ensure_dirs, load_jobs, save_jobs
+from .upload_security import remove_upload
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +62,12 @@ class JobManager:
 
         ensure_dirs([self.jobs_dir, self.backups_dir])
         self._jobs = load_jobs(self.jobs_dir)
+        # Passwords are process-only secrets. Remove values written by older releases.
+        for job in self._jobs.values():
+            job.pop("password", None)
+        save_jobs(self.jobs_dir, self._jobs)
+        self._passwords = {}
+        self._temporary_inputs = set()
         self.queues = {}
         self.executor = ThreadPoolExecutor(max_workers=2)
         self.lock = threading.Lock()
@@ -112,7 +119,7 @@ class JobManager:
             return None
         return self.queues.get(job_id)
 
-    def create_job(self, input_path, original_name=None, password=None):
+    def create_job(self, input_path, original_name=None, password=None, cleanup_input=False):
         job_id = uuid.uuid4().hex
         job = {
             "id": job_id,
@@ -123,11 +130,14 @@ class JobManager:
             "backups": [],
             "log": [],
             "stats": {},
-            "password": password,
         }
         q = queue.Queue()
         with self.lock:
             self._jobs[job_id] = job
+            if password:
+                self._passwords[job_id] = password
+            if cleanup_input:
+                self._temporary_inputs.add(job_id)
             self.queues[job_id] = q  # Register queue before saving jobs
             save_jobs(self.jobs_dir, self._jobs)
         self.executor.submit(self._run_job, job_id)
@@ -330,7 +340,7 @@ class JobManager:
                         },
                     )
                     sys.stdout = captured_output
-                    pwd = job.get("password")
+                    pwd = self._passwords.get(job_id)
                     knxproj = XKNXProj(path=job["input"], password=pwd, language="de-DE")
                     project = knxproj.parse()
                     sys.stdout = old_stdout
@@ -522,6 +532,10 @@ class JobManager:
                     knxmod.config["openhab_path"] = original_openhab_path
                 except Exception:
                     pass
+            self._passwords.pop(job_id, None)
+            if job_id in self._temporary_inputs:
+                remove_upload(job.get("input"))
+                self._temporary_inputs.discard(job_id)
             save_jobs(self.jobs_dir, self._jobs)
             q.put(None)
 
@@ -890,5 +904,7 @@ class JobManager:
             del self._jobs[job_id]
             if job_id in self.queues:
                 del self.queues[job_id]
+            self._passwords.pop(job_id, None)
+            self._temporary_inputs.discard(job_id)
             save_jobs(self.jobs_dir, self._jobs)
         return True

--- a/web_ui/backend/upload_security.py
+++ b/web_ui/backend/upload_security.py
@@ -1,0 +1,101 @@
+"""Validation and isolated storage for untrusted KNX project uploads."""
+
+import json
+import os
+import shutil
+import stat
+import tempfile
+import zipfile
+from pathlib import PurePosixPath
+
+
+class UploadValidationError(ValueError):
+    """Raised when an uploaded project violates a security limit."""
+
+
+DEFAULT_MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+DEFAULT_MAX_FILES = 10_000
+DEFAULT_MAX_UNCOMPRESSED_BYTES = 250 * 1024 * 1024
+DEFAULT_MAX_COMPRESSION_RATIO = 100
+SUPPORTED_EXTENSIONS = (".knxprojarchive.json", ".knxprojarchive", ".knxproj", ".json")
+
+
+def supported_extension(filename):
+    lower_name = filename.lower()
+    return next((suffix for suffix in SUPPORTED_EXTENSIONS if lower_name.endswith(suffix)), None)
+
+
+def validate_project(path, filename, limits=None):
+    """Validate the filename and content without extracting an archive."""
+    limits = limits or {}
+    extension = supported_extension(filename)
+    if extension is None:
+        raise UploadValidationError(
+            "Unsupported file type. Use .knxproj, .knxprojarchive, or .json."
+        )
+
+    if extension.endswith(".json"):
+        try:
+            with open(path, "r", encoding="utf-8") as stream:
+                value = json.load(stream)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise UploadValidationError("The uploaded .json file is not valid JSON.") from error
+        if not isinstance(value, dict):
+            raise UploadValidationError("The uploaded project JSON must contain an object.")
+        return
+
+    if not zipfile.is_zipfile(path):
+        raise UploadValidationError("The uploaded KNX project is not a valid ZIP archive.")
+
+    max_files = int(limits.get("max_files", DEFAULT_MAX_FILES))
+    max_size = int(limits.get("max_uncompressed_bytes", DEFAULT_MAX_UNCOMPRESSED_BYTES))
+    max_ratio = int(limits.get("max_compression_ratio", DEFAULT_MAX_COMPRESSION_RATIO))
+    total_size = 0
+    with zipfile.ZipFile(path) as archive:
+        entries = archive.infolist()
+        if len(entries) > max_files:
+            raise UploadValidationError(f"Archive contains too many files (maximum {max_files}).")
+        for entry in entries:
+            normalized = entry.filename.replace("\\", "/")
+            member = PurePosixPath(normalized)
+            if member.is_absolute() or ".." in member.parts:
+                raise UploadValidationError("Archive contains an unsafe path.")
+            mode = entry.external_attr >> 16
+            if stat.S_ISLNK(mode):
+                raise UploadValidationError("Archive contains an unsupported symbolic link.")
+            total_size += entry.file_size
+            if total_size > max_size:
+                raise UploadValidationError(
+                    f"Archive expands beyond the {max_size // (1024 * 1024)} MB limit."
+                )
+            if entry.file_size and entry.compress_size == 0:
+                raise UploadValidationError("Archive contains a suspicious compressed file.")
+            if entry.compress_size and entry.file_size / entry.compress_size > max_ratio:
+                raise UploadValidationError("Archive contains a suspicious compression ratio.")
+
+
+def store_validated_upload(file_storage, filename, parent_dir, limits=None):
+    """Store one upload in a private temporary directory and validate it."""
+    limits = limits or {}
+    os.makedirs(parent_dir, mode=0o700, exist_ok=True)
+    work_dir = tempfile.mkdtemp(prefix="upload-", dir=parent_dir)
+    extension = supported_extension(filename) or ".upload"
+    path = os.path.join(work_dir, f"project{extension}")
+    try:
+        file_storage.save(path)
+        max_bytes = int(limits.get("max_upload_bytes", DEFAULT_MAX_UPLOAD_BYTES))
+        if os.path.getsize(path) > max_bytes:
+            raise UploadValidationError(
+                f"Upload exceeds the {max_bytes // (1024 * 1024)} MB size limit."
+            )
+        validate_project(path, filename, limits)
+        return path
+    except Exception:
+        shutil.rmtree(work_dir, ignore_errors=True)
+        raise
+
+
+def remove_upload(path):
+    """Remove the isolated directory containing an upload."""
+    if path:
+        shutil.rmtree(os.path.dirname(path), ignore_errors=True)


### PR DESCRIPTION
### Motivation
- Prevent malicious or malformed KNX project uploads from writing outside the working tree or exhausting resources. 
- Ensure upload processing runs in isolated temporary storage and leaves no sensitive artifacts behind. 
- Avoid persisting passphrases for password-protected projects and provide clear client errors for common failure modes.

### Description
- Add `web_ui/backend/upload_security.py` implementing extension checks, ZIP signature validation, path-traversal and symlink rejection, limits for file count, uncompressed size, compression ratio, and isolated temporary storage with reliable cleanup. 
- Wire validation and isolated storage into the Flask endpoints for upload and project preview (`web_ui/backend/app.py`) and return user-friendly 4xx messages for validation failures, including a configurable `MAX_CONTENT_LENGTH`. 
- Keep project passwords in process memory only by storing them in `JobManager._passwords`, scrub legacy `password` fields from persisted job files, and track temporary inputs for post-processing cleanup (`web_ui/backend/jobs.py`). 
- Add configuration defaults in `web_ui/backend/config.json` under `upload_security` and new tests `tests/test_upload_security.py` that cover traversal archives, excessive entries, ZIP-bomb characteristics, extension/content mismatches, JSON validation, cleanup behavior, and password persistence.

### Testing
- Ran unit tests for the new security checks and related endpoints with `pytest -q -o addopts='' tests/test_upload_security.py tests/test_web_ui_job_endpoints.py` and they passed locally. 
- Ran the full non-UI test suite with `pytest -q -o addopts='' tests --ignore=tests/ui` resulting in `279 passed, 12 skipped`. 
- Formatting and import checks were run with `black --check` and `isort --check-only` on modified files and succeeded in this environment, and `git diff --check` reported no issues. 
- UI tests were not executed because Playwright is not available in the execution environment, and `flake8` was not available in the environment (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a675033a5f483279d096704b218b233)