### PR TITLE
feat: add native openHAB 5.2 YAML output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,10 @@ Target audience: German-speaking smart home users running OpenHAB on Raspberry P
       get_addresses()        → flat list of group addresses with metadata
       put_addresses_in_building() → addresses placed into building tree
   → ets_to_openhab.py
-      gen_building()         → generates items/things/sitemap strings (500+ lines)
+      gen_building()         → generates legacy strings and a structured openHAB model
+  → openhab_yaml.py
+      validate_model()       → validates IDs and cross-references
+      render_yaml()          → deterministic openHAB 5.2 YAML
       export_output()        → writes files using *.template wrappers
   → openhab/ output directory
       knx.items, knx.things, knx.sitemap, influxdb.persist
@@ -28,6 +31,7 @@ Target audience: German-speaking smart home users running OpenHAB on Raspberry P
 |------|---------|
 | `knxproject_to_openhab.py` | Entry point: parses `.knxproj`, builds building hierarchy, calls generator (789 lines) |
 | `ets_to_openhab.py` | Core generator: `gen_building()` produces items/things/sitemap strings, `export_output()` writes files (1058 lines) |
+| `openhab_yaml.py` | Dependency-free openHAB 5.2 YAML renderer and semantic validator |
 | `config.json` | Central config: regex patterns, device detection rules, datapoint mappings, output paths (500 lines) |
 | `config.py` | Loads `config.json`, normalizes values, detects OpenHAB paths. **Executes on import** — side effects at module level |
 | `utils.py` | Single helper: `get_datapoint_type()` |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Includes a **Web UI** for browser-based management and a **CLI** for automated w
 ## Features
 
 - **Automated Generation** — Creates Things, Items, Sitemaps, and Persistence rules in one step
+- **openHAB 5.2 YAML** — Optionally combines Things, Items, semantic metadata, channels, and the Sitemap in one native, versioned YAML file
 - **Smart Detection** — Identifies Dimmers, Rollershutters, Thermostats, and multi-address components by DPT analysis and naming conventions
 - **Web Interface** — Drag-and-drop upload, live progress streaming (SSE), job history, diff viewer, deploy/rollback
 - **Backup & Rollback** — Automatic tar.gz backup before each generation, restore any previous version
@@ -87,10 +88,13 @@ For each KNX project, the generator produces:
 
 | File | Contents |
 |------|----------|
+| `yaml/knx.yaml` | Native openHAB 5.2 model containing Things, Items, links, metadata, and Sitemap (when `output_format` is `yaml`) |
 | `knx.items` | Item definitions with types, icons, semantics, HomeKit/Alexa metadata |
 | `knx.things` | Thing definitions with KNX bridge and channel mappings |
 | `knx.sitemap` | Sitemap with floor/room hierarchy and labeled widgets |
 | `influxdb.persist` | InfluxDB persistence rules for items tagged with `influx` |
+
+The three legacy model files are mutually exclusive with `yaml/knx.yaml`. Persistence remains textual because openHAB 5.2 does not expose persistence as a YAML top-level entity. See the [YAML migration guide](docs/USER_GUIDE.md#openhab-52-yaml-output).
 
 ### Reports & Auto-Placement
 

--- a/config.json
+++ b/config.json
@@ -487,6 +487,7 @@
   },
   "influx_path": "openhab/persistence/influxdb.persist",
   "items_path": "openhab/items/knx.items",
+  "output_format": "legacy",
   "regexpattern": {
     "item_Floor": "^=?[1-9\\.A-Z]{1,5}",
     "item_Floor_nameshort": "^=?[a-zA-Z]{1,5}\\b",
@@ -495,6 +496,8 @@
     "items_Name": "[^A-Za-z0-9_]+"
   },
   "sitemaps_path": "openhab/sitemaps/knx.sitemap",
+  "sitemap_label": "MiCasa",
   "things_path": "openhab/things/knx.things",
-  "transform_dir_path": "openhab/transform"
+  "transform_dir_path": "openhab/transform",
+  "yaml_path": "openhab/yaml/knx.yaml"
 }

--- a/config.py
+++ b/config.py
@@ -141,6 +141,7 @@ def main():
     # We should replace the leading 'openhab' (or base) with oh_conf if it's absolute.
 
     paths_to_update = [
+        "yaml_path",
         "items_path",
         "things_path",
         "sitemaps_path",
@@ -177,6 +178,8 @@ def main():
                     # Let's map based on parent dir name.
                     if "items" in p.parts:
                         config[key] = str(Path(oh_conf) / "items" / p.name)
+                    elif "yaml" in p.parts:
+                        config[key] = str(Path(oh_conf) / "yaml" / p.name)
                     elif "things" in p.parts:
                         config[key] = str(Path(oh_conf) / "things" / p.name)
                     elif "sitemaps" in p.parts:
@@ -196,6 +199,9 @@ def main():
     config["target_user"] = oh_user
     config["target_group"] = oh_group
     config["openhab_path"] = oh_conf
+    config.setdefault("output_format", "legacy")
+    config.setdefault("yaml_path", str(Path(oh_conf) / "yaml" / "knx.yaml"))
+    config.setdefault("sitemap_label", "MiCasa")
 
 
 # if __name__ == "__main__":

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -78,6 +78,13 @@ The `config.json` file controls global settings for the generator.
 
 ### Key Settings
 
+- **`output_format`**: Selects the model format.
+  - `legacy` (default during the migration period): separate `.things`, `.items`, and `.sitemap` files.
+  - `yaml`: one native openHAB 5.2 `version: 1` model.
+
+- **`yaml_path`**: Target for the native YAML model.
+  - Default: `openhab/yaml/knx.yaml` (or `$OPENHAB_CONF/yaml/knx.yaml` when openHAB is detected).
+
 - **`drop_words`**: A list of words to remove from item labels to keep them short.
   - _Example_: If you have a group address "Kitchen Light Right", and "Light" is in `drop_words`, the label becomes "Kitchen Right" (assuming the icon already indicates it's a light).
   - _Note_: Words are NOT dropped if doing so would result in an empty label.
@@ -96,6 +103,25 @@ The `config.json` file controls global settings for the generator.
 
 - **`switch`**: Configuration for switch detection.
   - `status_suffix`: Suffixes identifying the status GA (e.g., "Status", "Rückmeldung").
+
+## openHAB 5.2 YAML Output
+
+Set `output_format` to `yaml` in the Web UI or `config.json` to generate a native openHAB 5.2 file:
+
+```json
+{
+  "output_format": "yaml",
+  "yaml_path": "openhab/yaml/knx.yaml"
+}
+```
+
+The resulting document contains `version: 1` and the `things`, `items`, and `sitemaps` sections. The generator validates Item names, parent Groups, Bridge references, Item-channel links, and Sitemap Item references before replacing the target file.
+
+Migration is intentionally explicit: never load the generated legacy model files and `knx.yaml` at the same time, because they define the same entity IDs. A Web UI deployment backs up the live configuration and then retires the generated files from the other format. Rollback restores the backed-up configuration.
+
+`influxdb.persist` remains in the persistence directory. The existing stateful `fenster.rules` also remains textual; wrapping its body in a YAML Script action would reset its counters and change the 15-minute notification behavior.
+
+Official format reference: [openHAB YAML Configuration](https://www.openhab.org/docs/configuration/yaml/).
 
 ---
 

--- a/ets_to_openhab.py
+++ b/ets_to_openhab.py
@@ -8,6 +8,18 @@ from typing import Any
 
 from config import config, datapoint_mappings, normalize_string
 from ets_helpers import flags_match, get_co_flags, get_dpt_from_dco
+from openhab_yaml import (
+    add_channel,
+    add_item,
+    new_model,
+    normalize_icon,
+    parse_assignments,
+    parse_item_type,
+    parse_metadata,
+    parse_tags,
+    parse_visibility,
+    write_yaml,
+)
 from utils import get_datapoint_type
 
 logger = logging.getLogger(__name__)
@@ -32,7 +44,7 @@ FENSTERKONTAKTE: list[str] = []
 PRJ_NAME = "Our Home"
 
 
-def gen_building():
+def gen_building(include_yaml_model=False):
     """Generates a Building from an ETS Project"""
 
     def get_co_by_functiontext(cos, config_functiontexts, checkwriteflag=True):
@@ -269,7 +281,7 @@ def gen_building():
         # floor_configuration += f"Group:Switch:OR(ON, OFF)       map{floor_nr}_Presence       \"{floor_variables['name']} Präsenz [MAP(presence.map):%s]\"      <presence>         (map{floor_nr},Base)                  [\"Presence\"] \n"
         # floor_configuration += f"Group:Contact:OR(OPEN, CLOSED) map{floor_nr}_Contacts       \"{floor_variables['name']} Öffnungsmelder\"                      <contact>          (map{floor_nr})                [\"OpenState\"] \n"
         # floor_configuration += f"Group:Number:Temperature:AVG   map{floor_nr}_Temperature    \"{floor_variables['name']} Ø Temperatur\"                        <temperature>      (map{floor_nr})             [\"Measurement\", \"Temperature\"]        {{stateDescription=\"\"[pattern=\"%.1f %unit%\"]}} \n"
-        return floor_configuration, floor_name
+        return floor_configuration, floor_name, floor_variables
 
     def generate_room_configuration(room, floor_nr, room_nr):
         """
@@ -296,14 +308,33 @@ def gen_building():
     items = ""
     sitemap = ""
     things = ""
+    yaml_model = new_model(PRJ_NAME, GWIP, config.get("sitemap_label", "MiCasa"))
+    yaml_sitemap_widgets = yaml_model["sitemaps"]["knx"]["widgets"]
     floor_nr = 0
     homekit_instance = 1
     homekit_accessorie = 0
     for floor in floors:
         floor_nr += 1
-        floor_configuration, floor_name = generate_floor_configuration(floor, floor_nr)
+        floor_configuration, floor_name, floor_variables = generate_floor_configuration(
+            floor, floor_nr
+        )
         items += floor_configuration
         sitemap += f'Frame label="{floor_name}" {{\n'
+        floor_item: dict[str, Any] = {
+            "type": "Group",
+            "label": floor_variables["name"],
+            "icon": normalize_icon(floor_variables["icon"]),
+            "groups": ["Base"],
+            "tags": parse_tags(floor_variables["semantic"]),
+            "metadata": parse_metadata(floor_variables["synonyms"]),
+        }
+        add_item(yaml_model, f"map{floor_nr}", floor_item)
+        yaml_floor_widget: dict[str, Any] = {
+            "type": "Frame",
+            "label": floor_name,
+            "widgets": [],
+        }
+        yaml_sitemap_widgets.append(yaml_floor_widget)
 
         room_nr = 0
         for room in floor["rooms"]:
@@ -314,6 +345,24 @@ def gen_building():
             items += room_configuration
             sitemap += f"     Group item=map{floor_nr}_{room_nr} {room_variables['visibility']} label=\"{room_name}\" "
             group = ""
+            room_item: dict[str, Any] = {
+                "type": "Group",
+                "label": room_variables["name"],
+                "icon": normalize_icon(room_variables["icon"]),
+                "groups": [f"map{floor_nr}"],
+                "tags": parse_tags(room_variables["semantic"]),
+                "metadata": parse_metadata(room_variables["synonyms"]),
+            }
+            room_item_name = f"map{floor_nr}_{room_nr}"
+            add_item(yaml_model, room_item_name, room_item)
+            yaml_room_widget: dict[str, Any] = {
+                "type": "Group",
+                "item": room_item_name,
+                "label": room_name,
+            }
+            if visibility := parse_visibility(room_variables["visibility"]):
+                yaml_room_widget["visibility"] = visibility
+            yaml_floor_widget["widgets"].append(yaml_room_widget)
 
             addresses = room["Addresses"]
             logger.debug("Room: %s and %s Adresses", room_name, len(addresses))
@@ -729,6 +778,13 @@ def gen_building():
 
                         thing_type = item_type.lower().split(":")[0]
                         things += f"Type {thing_type}    :   {item_name}   \"{address['Group name']}\"   [ {thing_address_info} ]\n"
+                        channel_uid = add_channel(
+                            yaml_model,
+                            item_name,
+                            thing_type,
+                            address["Group name"],
+                            parse_assignments(thing_address_info),
+                        )
 
                         root = f"map{floor_nr}_{room_nr}"
 
@@ -750,6 +806,18 @@ def gen_building():
                                 if grp_metadata:
                                     grp_metadata = f"{{ {grp_metadata} }}"
                                 items += f'Group   equipment_{item_name}   "{item_label}"  {item_icon}  ({root})   ["{equipment}"] {grp_metadata}\n'
+                                add_item(
+                                    yaml_model,
+                                    f"equipment_{item_name}",
+                                    {
+                                        "type": "Group",
+                                        "label": item_label,
+                                        "icon": normalize_icon(item_icon),
+                                        "groups": [root],
+                                        "tags": [equipment],
+                                        "metadata": parse_metadata(grp_metadata),
+                                    },
+                                )
                                 root = f"equipment_{item_name}"
                             else:
                                 root = f"equipment_{equipments[item_label]}"
@@ -771,6 +839,26 @@ def gen_building():
 
                         items += f'{item_type}   {item_name}   "{item_label}"   {item_icon}   ({root})   {semantic_info}    {{ channel="knx:device:bridge:generic:{item_name}" {metadata}{synonyms} }}\n'
                         group += f"        {sitemap_type} item={item_name} label=\"{item_label}\" {item_variables['visibility']}\n"
+                        yaml_item = parse_item_type(item_type)
+                        yaml_item.update(
+                            {
+                                "label": item_label,
+                                "icon": normalize_icon(item_icon),
+                                "groups": [entry.strip() for entry in root.split(",")],
+                                "tags": parse_tags(semantic_info),
+                                "channel": channel_uid,
+                                "metadata": parse_metadata(metadata, synonyms),
+                            }
+                        )
+                        add_item(yaml_model, item_name, yaml_item)
+                        yaml_widget: dict[str, Any] = {
+                            "type": sitemap_type,
+                            "item": item_name,
+                            "label": item_label,
+                        }
+                        if visibility := parse_visibility(item_variables["visibility"]):
+                            yaml_widget["visibility"] = visibility
+                        yaml_room_widget.setdefault("widgets", []).append(yaml_widget)
 
                         if homekit_accessorie >= HOMEKIT_MAX_ACCESSORIES_PER_INSTANCE:
                             homekit_accessorie = 0
@@ -791,6 +879,8 @@ def gen_building():
             else:
                 sitemap += "\n"
         sitemap += "}\n"
+    if include_yaml_model:
+        return items, sitemap, things, yaml_model
     return items, sitemap, things
 
 
@@ -871,15 +961,8 @@ def write_partial_report(cfg):
         logger.warning("Failed to write partial_report.json: %s", e)
 
 
-def export_output(items, sitemap, things, configuration=None):
-    """Exports things / items / sitemap / ...  Files"""
-    # Use provided configuration or fallback to global config
-    cfg = configuration if configuration is not None else config
-
-    # write partial report if any
-    write_partial_report(cfg)
-
-    # export things:
+def _export_legacy_model(items, sitemap, things, cfg):
+    """Write the pre-5.2 textual Things, Items and Sitemap files."""
     try:
         things_template = open("things.template", "r", encoding="utf8").read()
         if GWIP:
@@ -930,6 +1013,25 @@ def export_output(items, sitemap, things, configuration=None):
     except Exception as e:
         logger.error(f"Failed to write sitemap file to {cfg['sitemaps_path']}: {e}")
         raise
+
+
+def export_output(items, sitemap, things, configuration=None, yaml_model=None):
+    """Export the generated openHAB model plus legacy persistence/rules files."""
+    cfg = configuration if configuration is not None else config
+    output_format = str(cfg.get("output_format", "legacy")).casefold()
+    if output_format not in {"legacy", "yaml"}:
+        raise ValueError('output_format must be either "legacy" or "yaml"')
+
+    write_partial_report(cfg)
+
+    if output_format == "yaml":
+        if yaml_model is None:
+            raise ValueError("yaml_model is required when output_format is yaml")
+        yaml_path = cfg.get("yaml_path", "openhab/yaml/knx.yaml")
+        write_yaml(yaml_path, yaml_model)
+        logger.info("Successfully wrote openHAB 5.2 YAML configuration to %s", yaml_path)
+    else:
+        _export_legacy_model(items, sitemap, things, cfg)
 
     # export persistent
     private_persistence = ""
@@ -994,9 +1096,23 @@ def export_output(items, sitemap, things, configuration=None):
 def main(configuration=None):
     """Main function"""
     logging.basicConfig()
-    items, sitemap, things = gen_building()
+    cfg = configuration if configuration is not None else config
+    include_yaml_model = str(cfg.get("output_format", "legacy")).casefold() == "yaml"
+    generated = gen_building(include_yaml_model=include_yaml_model)
+    if include_yaml_model:
+        items, sitemap, things, yaml_model = generated
+    else:
+        items, sitemap, things = generated
+        yaml_model = None
     check_unused_addresses()
-    export_output(items, sitemap, things, configuration=configuration)
+    export_output(
+        items,
+        sitemap,
+        things,
+        configuration=configuration,
+        yaml_model=yaml_model,
+    )
+    return {"things": things, "yaml_model": yaml_model}
 
 
 if __name__ == "__main__":

--- a/openhab_yaml.py
+++ b/openhab_yaml.py
@@ -1,0 +1,282 @@
+"""Structured openHAB 5.2 YAML model generation and validation.
+
+The openHAB YAML format is a versioned, modular configuration format.  This
+module deliberately works with Python mappings instead of converting complete
+legacy DSL files.  The small parsing helpers only translate the generator's
+existing metadata/config fragments at the point where those fragments are
+created.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+OPENHAB_YAML_VERSION = 1
+KNX_BRIDGE_UID = "knx:ip:bridge"
+KNX_DEVICE_UID = "knx:device:bridge:generic"
+
+_ASSIGNMENT = re.compile(r'(\w+)\s*=\s*"([^"]*)"\s*(?:\[\s*([^]]*)\s*\])?')
+_ITEM_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SITEMAP_NAME = re.compile(r"^[A-Za-z0-9_]+$")
+_PLAIN_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:-]*$")
+_VISIBILITY = re.compile(
+    r"visibility=\[\s*([A-Za-z_][A-Za-z0-9_]*)\s*(==|!=|<=|>=|<|>)\s*([^]]+)\s*\]"
+)
+
+
+class YamlModelValidationError(ValueError):
+    """Raised when a generated model cannot be loaded safely by openHAB."""
+
+
+def new_model(project_name: str, gateway_ip: str | None, sitemap_label: str) -> dict[str, Any]:
+    """Create the fixed openHAB/KNX model roots used by the generator."""
+    bridge_config: dict[str, Any] = {
+        "type": "TUNNEL" if gateway_ip else "ROUTER",
+        "autoReconnectPeriod": 30 if gateway_ip else 60,
+    }
+    if gateway_ip:
+        bridge_config["ipAddress"] = gateway_ip
+        bridge_config["portNumber"] = 3671
+
+    return {
+        "version": OPENHAB_YAML_VERSION,
+        "things": {
+            KNX_BRIDGE_UID: {
+                "isBridge": True,
+                "config": bridge_config,
+            },
+            KNX_DEVICE_UID: {
+                "bridge": KNX_BRIDGE_UID,
+                "channels": {},
+            },
+        },
+        "items": {
+            "Base": {
+                "type": "Group",
+                "label": project_name,
+                "icon": "house",
+                "tags": ["Location"],
+            }
+        },
+        "sitemaps": {
+            "knx": {
+                "label": sitemap_label,
+                "widgets": [],
+            }
+        },
+    }
+
+
+def parse_assignments(fragment: str) -> dict[str, str]:
+    """Parse the key/value subset emitted for KNX channel configuration."""
+    return {match.group(1): match.group(2) for match in _ASSIGNMENT.finditer(fragment)}
+
+
+def parse_metadata(*fragments: str) -> dict[str, dict[str, Any]]:
+    """Translate generated openHAB DSL metadata fragments to YAML metadata maps."""
+    metadata: dict[str, dict[str, Any]] = {}
+    for fragment in fragments:
+        for match in _ASSIGNMENT.finditer(fragment or ""):
+            namespace, value, config_fragment = match.groups()
+            entry: dict[str, Any] = {"value": value}
+            if config_fragment:
+                entry["config"] = parse_assignments(config_fragment)
+            metadata[namespace] = entry
+    return metadata
+
+
+def parse_tags(fragment: str) -> list[str]:
+    """Return quoted tags from the generator's legacy tag fragment."""
+    return [tag for tag in re.findall(r'"([^"]*)"', fragment or "") if tag]
+
+
+def parse_item_type(item_type: str) -> dict[str, str]:
+    """Split DSL dimension syntax (for example Number:Temperature)."""
+    base_type, separator, dimension = item_type.partition(":")
+    result = {"type": base_type}
+    if separator and base_type.casefold() == "number":
+        result["dimension"] = dimension
+    return result
+
+
+def normalize_icon(icon: str | None) -> str | None:
+    """Convert DSL icon brackets to the plain YAML icon name."""
+    if not icon:
+        return None
+    return icon.removeprefix("<").removesuffix(">") or None
+
+
+def parse_visibility(fragment: str) -> dict[str, str] | None:
+    """Convert the simple sitemap visibility expression emitted by this project."""
+    match = _VISIBILITY.search(fragment or "")
+    if not match:
+        return None
+    item, operator, argument = match.groups()
+    return {"item": item, "operator": operator, "argument": argument.strip()}
+
+
+def add_item(model: dict[str, Any], name: str, item: Mapping[str, Any]) -> None:
+    """Add one Item while failing early on duplicate generated names."""
+    items = model["items"]
+    if name in items:
+        raise YamlModelValidationError(f'duplicate generated Item name "{name}"')
+    items[name] = {key: value for key, value in item.items() if value not in (None, [], {})}
+
+
+def add_channel(
+    model: dict[str, Any], channel_id: str, channel_type: str, label: str, config: Mapping[str, Any]
+) -> str:
+    """Add a custom KNX channel and return its complete channel UID."""
+    channels = model["things"][KNX_DEVICE_UID]["channels"]
+    if channel_id in channels:
+        raise YamlModelValidationError(f'duplicate generated KNX channel "{channel_id}"')
+    channels[channel_id] = {
+        "type": channel_type,
+        "label": label,
+        "config": dict(config),
+    }
+    return f"{KNX_DEVICE_UID}:{channel_id}"
+
+
+def _iter_sitemap_widgets(widgets: Iterable[Mapping[str, Any]]) -> Iterable[Mapping[str, Any]]:
+    for widget in widgets:
+        yield widget
+        yield from _iter_sitemap_widgets(widget.get("widgets", []))
+
+
+def validate_model(model: Mapping[str, Any]) -> None:
+    """Validate cross-references and openHAB 5.2 model constraints."""
+    errors: list[str] = []
+    if model.get("version") != OPENHAB_YAML_VERSION:
+        errors.append("top-level version must be 1")
+
+    things = model.get("things")
+    items = model.get("items")
+    sitemaps = model.get("sitemaps")
+    if not isinstance(things, Mapping):
+        errors.append("things must be a map")
+        things = {}
+    if not isinstance(items, Mapping):
+        errors.append("items must be a map")
+        items = {}
+    if not isinstance(sitemaps, Mapping):
+        errors.append("sitemaps must be a map")
+        sitemaps = {}
+
+    group_names = {
+        name
+        for name, item in items.items()
+        if isinstance(item, Mapping) and item.get("type") == "Group"
+    }
+    for name, item in items.items():
+        if not _ITEM_NAME.fullmatch(str(name)):
+            errors.append(f'invalid Item name "{name}"')
+        if not isinstance(item, Mapping) or not item.get("type"):
+            errors.append(f'Item "{name}" has no type')
+            continue
+        for group in item.get("groups", []):
+            if group not in group_names:
+                errors.append(f'Item "{name}" references missing Group "{group}"')
+
+        links: list[str] = []
+        if channel := item.get("channel"):
+            links.append(str(channel))
+        links.extend(str(channel) for channel in item.get("channels", {}))
+        for channel_uid in links:
+            thing_uid, separator, channel_id = channel_uid.rpartition(":")
+            thing = things.get(thing_uid)
+            if not separator or not isinstance(thing, Mapping):
+                errors.append(f'Item "{name}" references missing Thing channel "{channel_uid}"')
+            elif channel_id not in thing.get("channels", {}):
+                errors.append(f'Item "{name}" references missing channel "{channel_uid}"')
+
+    for thing_uid, thing in things.items():
+        if isinstance(thing, Mapping) and (bridge_uid := thing.get("bridge")):
+            if bridge_uid not in things:
+                errors.append(f'Thing "{thing_uid}" references missing Bridge "{bridge_uid}"')
+
+    for sitemap_name, sitemap in sitemaps.items():
+        if not _SITEMAP_NAME.fullmatch(str(sitemap_name)):
+            errors.append(f'invalid Sitemap name "{sitemap_name}"')
+        if not isinstance(sitemap, Mapping):
+            errors.append(f'Sitemap "{sitemap_name}" must be a map')
+            continue
+        for widget in _iter_sitemap_widgets(sitemap.get("widgets", [])):
+            if item_name := widget.get("item"):
+                if item_name not in items:
+                    errors.append(f'Sitemap "{sitemap_name}" references missing Item "{item_name}"')
+
+    if errors:
+        raise YamlModelValidationError(
+            "Invalid generated openHAB YAML model:\n- " + "\n- ".join(errors)
+        )
+
+
+def _scalar(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _key(value: Any) -> str:
+    text = str(value)
+    return text if _PLAIN_KEY.fullmatch(text) else json.dumps(text, ensure_ascii=False)
+
+
+def _emit(value: Any, indent: int = 0) -> list[str]:
+    prefix = " " * indent
+    if isinstance(value, Mapping):
+        if not value:
+            return [prefix + "{}"]
+        lines: list[str] = []
+        for key, child in value.items():
+            key_text = _key(key)
+            if isinstance(child, Mapping):
+                if child:
+                    lines.append(f"{prefix}{key_text}:")
+                    lines.extend(_emit(child, indent + 2))
+                else:
+                    lines.append(f"{prefix}{key_text}: {{}}")
+            elif isinstance(child, list):
+                if child:
+                    lines.append(f"{prefix}{key_text}:")
+                    lines.extend(_emit(child, indent + 2))
+                else:
+                    lines.append(f"{prefix}{key_text}: []")
+            else:
+                lines.append(f"{prefix}{key_text}: {_scalar(child)}")
+        return lines
+    if isinstance(value, list):
+        if not value:
+            return [prefix + "[]"]
+        lines = []
+        for child in value:
+            if isinstance(child, (Mapping, list)):
+                lines.append(prefix + "-")
+                lines.extend(_emit(child, indent + 2))
+            else:
+                lines.append(f"{prefix}- {_scalar(child)}")
+        return lines
+    return [prefix + _scalar(value)]
+
+
+def render_yaml(model: Mapping[str, Any]) -> str:
+    """Render deterministic, dependency-free YAML accepted by openHAB 5.2."""
+    validate_model(model)
+    return "\n".join(_emit(model)) + "\n"
+
+
+def write_yaml(path: str | Path, model: Mapping[str, Any]) -> None:
+    """Validate and atomically replace a generated YAML file."""
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.tmp")
+    temporary.write_text(render_yaml(model), encoding="utf-8")
+    temporary.replace(output)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ pytest-mock>=3.11.0
 pytest-playwright>=0.4.3
 pytest-timeout>=2.1.0
 pytest-xdist>=3.3.1  # For parallel test execution
+PyYAML>=6.0.2  # Parse generated YAML independently in tests
 
 # Code quality
 pylint>=2.17.0

--- a/tests/fixtures/synthetic_openhab_5_2.yaml
+++ b/tests/fixtures/synthetic_openhab_5_2.yaml
@@ -1,0 +1,47 @@
+version: 1
+things:
+  knx:ip:bridge:
+    isBridge: true
+    config:
+      type: "TUNNEL"
+      autoReconnectPeriod: 30
+      ipAddress: "192.0.2.1"
+      portNumber: 3671
+  knx:device:bridge:generic:
+    bridge: "knx:ip:bridge"
+    channels:
+      ExampleDimmer:
+        type: "dimmer"
+        label: "Example dimmer"
+        config:
+          position: "0/0/1+<0/0/2"
+items:
+  Base:
+    type: "Group"
+    label: "Example Home"
+    icon: "house"
+    tags:
+      - "Location"
+  ExampleRoom:
+    type: "Group"
+    label: "Example Room"
+    groups:
+      - "Base"
+    tags:
+      - "Room"
+  ExampleDimmer:
+    type: "Dimmer"
+    label: "Example Dimmer"
+    groups:
+      - "ExampleRoom"
+    tags:
+      - "Light"
+    channel: "knx:device:bridge:generic:ExampleDimmer"
+sitemaps:
+  knx:
+    label: "Example"
+    widgets:
+      -
+        type: "Default"
+        item: "ExampleDimmer"
+        label: "Example Dimmer"

--- a/tests/test_openhab_yaml.py
+++ b/tests/test_openhab_yaml.py
@@ -1,0 +1,206 @@
+import copy
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import ets_to_openhab
+import knxproject_to_openhab
+from config import config
+from openhab_yaml import (
+    YamlModelValidationError,
+    add_channel,
+    add_item,
+    new_model,
+    parse_metadata,
+    render_yaml,
+    validate_model,
+)
+
+MINI_PROJECT = Path(__file__).parent / "fixtures" / "mini_project.json"
+SYNTHETIC_YAML_GOLDEN = Path(__file__).parent / "fixtures" / "synthetic_openhab_5_2.yaml"
+YAML_CASES = [
+    Path(__file__).parent / "Charne.knxproj.json",
+    Path(__file__).parent / "upload.knxprojarchive.json",
+    MINI_PROJECT,
+]
+
+
+def _yaml_generation(project_path=MINI_PROJECT):
+    with open(project_path, encoding="utf-8") as file:
+        project = json.load(file)
+
+    building = knxproject_to_openhab.create_building(project)
+    addresses = knxproject_to_openhab.get_addresses(project)
+    house = knxproject_to_openhab.put_addresses_in_building(building, addresses, project)
+
+    ets_to_openhab.floors = house[0]["floors"]
+    ets_to_openhab.all_addresses = addresses
+    ets_to_openhab.GWIP = knxproject_to_openhab.get_gateway_ip(project)
+    ets_to_openhab.B_HOMEKIT = knxproject_to_openhab.is_homekit_enabled(project)
+    ets_to_openhab.B_ALEXA = knxproject_to_openhab.is_alexa_enabled(project)
+    ets_to_openhab.PRJ_NAME = house[0]["name_long"]
+    ets_to_openhab.equipments = {}
+    ets_to_openhab.used_addresses = []
+    ets_to_openhab.export_to_influx = []
+    ets_to_openhab.FENSTERKONTAKTE = []
+
+    return ets_to_openhab.gen_building(include_yaml_model=True)
+
+
+def _mini_yaml_model():
+    return _yaml_generation()[3]
+
+
+def _synthetic_yaml_model():
+    model = new_model("Example Home", "192.0.2.1", "Example")
+    add_item(
+        model,
+        "ExampleRoom",
+        {
+            "type": "Group",
+            "label": "Example Room",
+            "groups": ["Base"],
+            "tags": ["Room"],
+        },
+    )
+    channel_uid = add_channel(
+        model,
+        "ExampleDimmer",
+        "dimmer",
+        "Example dimmer",
+        {"position": "0/0/1+<0/0/2"},
+    )
+    add_item(
+        model,
+        "ExampleDimmer",
+        {
+            "type": "Dimmer",
+            "label": "Example Dimmer",
+            "groups": ["ExampleRoom"],
+            "tags": ["Light"],
+            "channel": channel_uid,
+        },
+    )
+    model["sitemaps"]["knx"]["widgets"].append(
+        {"type": "Default", "item": "ExampleDimmer", "label": "Example Dimmer"}
+    )
+    return model
+
+
+def test_mini_project_generates_native_openhab_52_model():
+    model = _mini_yaml_model()
+
+    validate_model(model)
+    assert model["version"] == 1
+    assert model["things"]["knx:ip:bridge"]["isBridge"] is True
+
+    channels = model["things"]["knx:device:bridge:generic"]["channels"]
+    assert channels["i_EG_RM1_DimmenDimmWert"]["type"] == "dimmer"
+    assert channels["i_EG_RM1_DimmenDimmWert"]["config"] == {
+        "position": "1/1/1+<1/1/2",
+        "switch": "1/1/3",
+    }
+    assert channels["i_EG_RM1_JalousieJalousieAufAb"]["config"] == {
+        "upDown": "1/2/1",
+        "stopMove": "1/2/2",
+        "position": "1/2/3",
+    }
+
+    items = model["items"]
+    dimmer = items["i_EG_RM1_DimmenDimmWert"]
+    assert dimmer["type"] == "Dimmer"
+    assert dimmer["groups"] == ["equipment_i_EG_RM1_DimmenDimmWert"]
+    assert dimmer["channel"] == ("knx:device:bridge:generic:i_EG_RM1_DimmenDimmWert")
+
+    sitemap = model["sitemaps"]["knx"]
+    assert sitemap["widgets"][0]["type"] == "Frame"
+    assert sitemap["widgets"][0]["widgets"][0]["item"] == "map1_1"
+    assert sitemap["widgets"][0]["widgets"][0]["widgets"][0]["type"] == "Default"
+
+
+@pytest.mark.parametrize("project_path", YAML_CASES, ids=lambda path: path.stem)
+def test_yaml_model_preserves_generated_entity_counts(project_path):
+    items_text, sitemap_text, things_text, model = _yaml_generation(project_path)
+
+    validate_model(model)
+    assert len(model["things"]["knx:device:bridge:generic"]["channels"]) == things_text.count(
+        "Type "
+    )
+    assert (
+        len(model["items"]) == len([line for line in items_text.splitlines() if line.strip()]) + 1
+    )  # Base comes from items.template in legacy output.
+
+    yaml_leaf_widgets = [
+        widget
+        for frame in model["sitemaps"]["knx"]["widgets"]
+        for room in frame.get("widgets", [])
+        for widget in room.get("widgets", [])
+    ]
+    legacy_leaf_widgets = sum(
+        1
+        for line in sitemap_text.splitlines()
+        if line.strip().startswith(("Default item=", "Selection item="))
+    )
+    assert len(yaml_leaf_widgets) == legacy_leaf_widgets
+
+
+def test_yaml_renderer_quotes_boolean_like_openhab_strings():
+    text = render_yaml(_mini_yaml_model())
+
+    assert yaml.safe_load(text) == _mini_yaml_model()
+    assert "version: 1" in text
+    assert "isBridge: true" in text
+    assert 'type: "TUNNEL"' in text
+    assert 'ga: "20.102:1/3/1+<1/3/2"' in text
+
+
+def test_synthetic_yaml_matches_reviewable_golden_file():
+    assert render_yaml(_synthetic_yaml_model()) == SYNTHETIC_YAML_GOLDEN.read_text(encoding="utf-8")
+
+
+def test_yaml_export_is_mutually_exclusive_with_legacy_model_files(tmp_path):
+    model = _mini_yaml_model()
+    cfg = copy.deepcopy(config)
+    cfg.update(
+        {
+            "output_format": "yaml",
+            "yaml_path": str(tmp_path / "yaml" / "knx.yaml"),
+            "items_path": str(tmp_path / "items" / "knx.items"),
+            "things_path": str(tmp_path / "things" / "knx.things"),
+            "sitemaps_path": str(tmp_path / "sitemaps" / "knx.sitemap"),
+            "influx_path": str(tmp_path / "persistence" / "influxdb.persist"),
+            "fenster_path": str(tmp_path / "rules" / "fenster.rules"),
+            "openhab_path": str(tmp_path),
+        }
+    )
+
+    ets_to_openhab.export_output("", "", "", configuration=cfg, yaml_model=model)
+
+    assert (tmp_path / "yaml" / "knx.yaml").is_file()
+    assert not (tmp_path / "items" / "knx.items").exists()
+    assert not (tmp_path / "things" / "knx.things").exists()
+    assert not (tmp_path / "sitemaps" / "knx.sitemap").exists()
+    assert (tmp_path / "persistence" / "influxdb.persist").is_file()
+    assert (tmp_path / "rules" / "fenster.rules").is_file()
+
+
+def test_metadata_conversion_preserves_value_and_configuration():
+    assert parse_metadata(
+        ', stateDescription=""[options="1=Comfort,2=Standby"], alexa="Switch"'
+    ) == {
+        "stateDescription": {
+            "value": "",
+            "config": {"options": "1=Comfort,2=Standby"},
+        },
+        "alexa": {"value": "Switch"},
+    }
+
+
+def test_model_validation_rejects_orphaned_groups():
+    model = _mini_yaml_model()
+    model["items"]["i_EG_RM1_DimmenDimmWert"]["groups"] = ["MissingGroup"]
+
+    with pytest.raises(YamlModelValidationError, match="MissingGroup"):
+        validate_model(model)

--- a/tests/test_output_config.py
+++ b/tests/test_output_config.py
@@ -73,6 +73,7 @@ class TestOutputConfig:
 
         expected_items = str(Path("/etc/openhab") / "items" / "knx.items")
         assert config.config["items_path"] == expected_items
+        assert config.config["yaml_path"] == str(Path("/etc/openhab") / "yaml" / "knx.yaml")
         assert config.config["target_user"] == "openhab"
         assert config.config["target_group"] == "openhab"
         logger.info(f"✓ OpenHAB CLI detection: items_path={config.config['items_path']}")

--- a/tests/test_web_ui_job_stats.py
+++ b/tests/test_web_ui_job_stats.py
@@ -24,3 +24,59 @@ def test_compute_staged_stats_compares_generated_file_with_live_file(tmp_path):
             "real_path": str(live_path),
         }
     }
+
+
+def test_compute_retired_stats_reports_legacy_files_as_deletions(tmp_path):
+    openhab_path = tmp_path / "openhab"
+    legacy_path = openhab_path / "items" / "knx.items"
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_text("one\ntwo\n", encoding="utf-8")
+
+    manager = JobManager.__new__(JobManager)
+    stats = manager._compute_retired_stats([str(legacy_path)], str(openhab_path))
+
+    assert stats["items/knx.items"] == {
+        "before": 2,
+        "after": 0,
+        "delta": -2,
+        "added": 0,
+        "removed": 2,
+        "staged_path": "",
+        "real_path": str(legacy_path),
+        "retired": True,
+    }
+
+
+def test_deploy_retires_legacy_model_only_after_backup(tmp_path):
+    openhab_path = tmp_path / "openhab"
+    legacy_path = openhab_path / "items" / "knx.items"
+    yaml_path = openhab_path / "yaml" / "knx.yaml"
+    staged_yaml = tmp_path / "staging" / "openhab" / "yaml" / "knx.yaml"
+    legacy_path.parent.mkdir(parents=True)
+    staged_yaml.parent.mkdir(parents=True)
+    legacy_path.write_text("legacy\n", encoding="utf-8")
+    staged_yaml.write_text("version: 1\n", encoding="utf-8")
+
+    manager = JobManager.__new__(JobManager)
+    manager.cfg = {"openhab_path": str(openhab_path)}
+    manager.backups_dir = str(tmp_path / "backups")
+    manager.jobs_dir = str(tmp_path / "jobs")
+    (tmp_path / "backups").mkdir()
+    (tmp_path / "jobs").mkdir()
+    manager._jobs = {
+        "job": {
+            "id": "job",
+            "staged": True,
+            "backups": [],
+            "stage_mapping": {str(staged_yaml): str(yaml_path)},
+            "retired_paths": [str(legacy_path)],
+        }
+    }
+
+    ok, message = manager.deploy("job")
+
+    assert ok is True
+    assert "retired 1" in message
+    assert yaml_path.read_text(encoding="utf-8") == "version: 1\n"
+    assert not legacy_path.exists()
+    assert manager._jobs["job"]["backups"]

--- a/web_ui/backend/config_schema.json
+++ b/web_ui/backend/config_schema.json
@@ -3,6 +3,19 @@
   "description": "Configuration settings for the KNX to OpenHAB converter",
   "type": "object",
   "properties": {
+    "output_format": {
+      "type": "string",
+      "title": "OpenHAB Model Format",
+      "description": "Use legacy textual files or one native openHAB 5.2 YAML model",
+      "enum": ["legacy", "yaml"],
+      "default": "legacy"
+    },
+    "yaml_path": {
+      "type": "string",
+      "title": "YAML Output Path",
+      "description": "Target path for the native openHAB 5.2 YAML model",
+      "default": "openhab/yaml/knx.yaml"
+    },
     "general": {
       "type": "object",
       "title": "General Settings",

--- a/web_ui/backend/jobs.py
+++ b/web_ui/backend/jobs.py
@@ -250,13 +250,19 @@ class JobManager:
             knxmod.config["openhab_path"] = staged_config["openhab_path"]
 
             # Define output keys to override
-            output_keys = [
-                "items_path",
-                "things_path",
-                "sitemaps_path",
-                "influx_path",
-                "fenster_path",
-            ]
+            output_format = str(staged_config.get("output_format", "legacy")).casefold()
+            model_output_keys = (
+                ["yaml_path"]
+                if output_format == "yaml"
+                else ["items_path", "things_path", "sitemaps_path"]
+            )
+            retired_keys = (
+                ["items_path", "things_path", "sitemaps_path"]
+                if output_format == "yaml"
+                else ["yaml_path"]
+            )
+            retired_paths = [staged_config[key] for key in retired_keys if staged_config.get(key)]
+            output_keys = model_output_keys + ["influx_path", "fenster_path"]
             stage_mapping = {}  # staged_path -> real_absolute_path
 
             q.put(
@@ -383,13 +389,14 @@ class JobManager:
                 sys.stdout = captured_output
 
                 # ets_to_openhab.main() writes output files to STAGING via injected config
-                etsmod.main(configuration=staged_config)
+                generation_result = etsmod.main(configuration=staged_config)
 
                 # Generate completeness report from staged knx.things
                 try:
                     report_path = self._write_completeness_report(
                         staged_config.get("things_path"),
                         staged_config.get("openhab_path", ""),
+                        things_text=generation_result.get("things"),
                     )
                     if report_path:
                         self._log_to_queue(
@@ -454,11 +461,13 @@ class JobManager:
             # Save staging info to job
             job["staging_dir"] = staging_dir
             job["stage_mapping"] = stage_mapping
+            job["retired_paths"] = retired_paths
             job["staged"] = True
 
             # Compute statistics by comparing STAGED vs LIVE/BACKUP
             try:
                 detailed_stats = self._compute_staged_stats(stage_mapping, openhab_path)
+                detailed_stats.update(self._compute_retired_stats(retired_paths, openhab_path))
                 job["stats"] = detailed_stats
 
                 for fn, stat in sorted(job["stats"].items()):
@@ -538,12 +547,12 @@ class JobManager:
             "label": match.group("label"),
         }
 
-    def _write_completeness_report(self, things_path, openhab_path):
-        if not things_path or not os.path.exists(things_path):
-            return None
-
-        with open(things_path, "r", encoding="utf-8", errors="ignore") as f:
-            things_text = f.read()
+    def _write_completeness_report(self, things_path, openhab_path, things_text=None):
+        if things_text is None:
+            if not things_path or not os.path.exists(things_path):
+                return None
+            with open(things_path, "r", encoding="utf-8", errors="ignore") as f:
+                things_text = f.read()
 
         missing_required_tuples, recommended_missing_tuples = check_completeness(things_text)
 
@@ -642,6 +651,42 @@ class JobManager:
                 "real_path": abs_real_path,
             }
 
+        return stats
+
+    def _compute_retired_stats(self, retired_paths, openhab_path):
+        """Report generated files that will be removed during a format transition."""
+        stats = {}
+        abs_openhab_path = os.path.normpath(os.path.abspath(openhab_path))
+        for path in retired_paths:
+            absolute_path = os.path.normpath(os.path.abspath(path))
+            if not os.path.isfile(absolute_path):
+                continue
+            try:
+                with open(absolute_path, "r", encoding="utf-8", errors="ignore") as file:
+                    before = len(file.readlines())
+            except OSError:
+                continue
+            try:
+                in_openhab = (
+                    os.path.commonpath([absolute_path, abs_openhab_path]) == abs_openhab_path
+                )
+            except ValueError:
+                in_openhab = False
+            relative_path = (
+                os.path.relpath(absolute_path, abs_openhab_path)
+                if in_openhab
+                else os.path.basename(absolute_path)
+            )
+            stats[relative_path.replace("\\", "/")] = {
+                "before": before,
+                "after": 0,
+                "delta": -before,
+                "added": 0,
+                "removed": before,
+                "staged_path": "",
+                "real_path": absolute_path,
+                "retired": True,
+            }
         return stats
 
     def get_file_diff(self, job_id, rel_path):
@@ -797,6 +842,7 @@ class JobManager:
             raise Exception(f"Backup failed, aborting deploy: {e}")
 
         deployed_count = 0
+        retired_count = 0
         try:
             for staged_path, real_path in mapping.items():
                 if os.path.exists(staged_path):
@@ -812,9 +858,23 @@ class JobManager:
                 else:
                     logger.warning(f"Staged file missing: {staged_path}")
 
+            deployed_targets = {
+                os.path.normpath(os.path.abspath(path)) for path in mapping.values()
+            }
+            for retired_path in job.get("retired_paths", []):
+                target = os.path.normpath(os.path.abspath(retired_path))
+                if target in deployed_targets:
+                    continue
+                if os.path.isfile(target):
+                    os.remove(target)
+                    retired_count += 1
+
             job["deployed"] = True
             save_jobs(self.jobs_dir, self._jobs)
-            return True, f"Deployed {deployed_count} files."
+            return (
+                True,
+                f"Deployed {deployed_count} files; retired {retired_count} old model files.",
+            )
 
         except Exception as e:
             logger.error(f"Deploy failed: {e}")

--- a/web_ui/static/app.js
+++ b/web_ui/static/app.js
@@ -1130,6 +1130,8 @@ async function loadConfig() {
 
     // Populate General Tab
     // ETS export path removed
+    document.getElementById('conf-output-format').value = currentConfig.output_format || 'legacy'
+    document.getElementById('conf-yaml-path').value = currentConfig.yaml_path || 'openhab/yaml/knx.yaml'
     document.getElementById('conf-items-path').value = currentConfig.items_path || ''
     document.getElementById('conf-things-path').value = currentConfig.things_path || ''
     document.getElementById('conf-sitemaps-path').value = currentConfig.sitemaps_path || ''
@@ -1280,6 +1282,8 @@ async function saveConfig(reprocess = false) {
 
     // General
     // ETS export path removed
+    newConfig.output_format = document.getElementById('conf-output-format').value
+    newConfig.yaml_path = document.getElementById('conf-yaml-path').value
     newConfig.items_path = document.getElementById('conf-items-path').value
     newConfig.things_path = document.getElementById('conf-things-path').value
     newConfig.sitemaps_path = document.getElementById('conf-sitemaps-path').value

--- a/web_ui/templates/index.html
+++ b/web_ui/templates/index.html
@@ -111,6 +111,18 @@
           <div id="tab-general" class="tab-content active">
             <!-- ETS Export Path removed -->
             <div class="form-group">
+              <label>OpenHAB Model Format</label>
+              <select id="conf-output-format" class="form-control">
+                <option value="legacy">Legacy DSL (.things/.items/.sitemap)</option>
+                <option value="yaml">openHAB 5.2 YAML</option>
+              </select>
+              <div class="checkbox-help">YAML combines Things, Items and the Sitemap in one versioned file. Persistence and the stateful window rule remain textual.</div>
+            </div>
+            <div class="form-group">
+              <label>YAML Path</label>
+              <input type="text" id="conf-yaml-path" class="form-control">
+            </div>
+            <div class="form-group">
               <label>Items Path</label>
               <input type="text" id="conf-items-path" class="form-control">
             </div>


### PR DESCRIPTION
Closes #38

## Summary

Adds an opt-in native openHAB 5.2 YAML output while keeping legacy output as the migration-safe default.

- builds a structured model alongside the existing renderer instead of parsing complete DSL output
- emits one deterministic `version: 1` YAML document with KNX Things/channels, Items/links/metadata, semantic groups, and Sitemap widgets
- validates duplicate IDs and cross-references before atomically replacing the YAML file
- exposes `output_format: legacy|yaml` and `yaml_path` in configuration and the Web UI
- stages only the selected model format
- creates a pre-deploy backup before retiring the exact generated files from the other format
- keeps `influxdb.persist` and the stateful `fenster.rules` textual
- documents migration and rollback

## openHAB 5.2 design basis

Implementation was checked against the official 5.2 documentation and the openHAB Core 5.2.0 YAML DTO/provider sources.

- model version is mandatory: `version: 1`
- Things are keyed by full UID; custom channels are nested under the Thing
- Number dimensions use the separate `dimension` field
- Item links use `channel` (or `channels` when link configuration is needed)
- Sitemaps are supported under the top-level `sitemaps` map in 5.2
- persistence is not a YAML top-level model
- the existing window rule cannot be wrapped naively in a YAML Script action because its DSL globals hold state between runs

References:

- https://www.openhab.org/docs/configuration/yaml/
- https://www.openhab.org/docs/configuration/yaml/things.html
- https://www.openhab.org/docs/configuration/yaml/items.html
- https://www.openhab.org/blog/2026-07-05-openhab-5-2-release.html

## Progress

- [x] Structured model generated at the same decision points as legacy output
- [x] Native Things, channels, Items, metadata, links, semantic hierarchy, and Sitemap
- [x] Deterministic dependency-free renderer with independent PyYAML parsing in tests
- [x] Cross-reference validation and atomic file replacement
- [x] Legacy/YAML configuration switch
- [x] Web UI staging, diff statistics, pre-deploy backup, exact old-file retirement, rollback
- [x] Mini, UploadJson, and Charne parity tests
- [x] Synthetic reviewable golden file
- [x] Migration documentation
- [x] GitHub CI: lint/typecheck, Python 3.12/3.13 core tests, Playwright UI tests
- [ ] Smoke-load generated output in a running openHAB 5.2 instance

## Verification

- local `pytest -q --ignore=tests/ui`: **282 passed, 12 skipped**
- GitHub CI run 422:
  - Lint (Black, isort, Flake8, Mypy): passed
  - Core Tests (Python 3.12): passed
  - Core Tests (Python 3.13): passed
  - UI Tests (Playwright): passed
- existing legacy integration goldens: unchanged and passing

## Compatibility / rollout

`legacy` remains the default. YAML and legacy model files must not coexist because they define the same UIDs. Web UI deployment backs up the live openHAB directory, deploys the selected format, and only then retires the exact generated files of the previous format.